### PR TITLE
feat(plugin-monorepo-readmes): add option to pass different targets to look README.md up

### DIFF
--- a/packages/plugin-monorepo-readmes/README.md
+++ b/packages/plugin-monorepo-readmes/README.md
@@ -36,4 +36,8 @@ For more infos, please refer to [the documentation](https://knodescommunity.gith
 
 ## Usage
 
-Simply create `README.md` files next to your `package.json` in your monorepo projects/workspaces.
+Simply create `README.md` files next to your `package.json` in your monorepo projects/workspaces. You can configure different files so the plugin find
+the README.md next to them. Example: If you have a NX Monorepo, you might have only one `package.json` in the root and the libraries would use a `project.json`
+file. In this case you would set the configuration `"readmeTargets": ["project.json", "package.json"]` and we would look for README.md near `project.json`
+and if none is found, we would fallback to `package.json`. Therefore you can see that the order of the files defined in the array is importante. You can pass
+any file in the array, so you could even use `"readmeTargets": ["README.md"]` and this would find the closest README.md to your module source. 

--- a/packages/plugin-monorepo-readmes/package.json
+++ b/packages/plugin-monorepo-readmes/package.json
@@ -36,7 +36,7 @@
   },
   "dependencies": {
     "@knodes/typedoc-pluginutils": "~0.22.4",
-    "pkg-up": "^3.1.0"
+    "find-up": "^4.1.0"
   },
   "peerDependencies": {
     "lodash": "^4.17.0",


### PR DESCRIPTION
In NX Monorepos we do not need a package.json into every library that we create since some of them will just be consumed within the monorepo and not published. Therefore we need a way to specify which files we want the plugin to look if the README.md is near them. This change introduces the configuration `readmeTargets`. Example of usage:
`"readmeTargets": ["project.json", "package.json"]`
This would look for README.md near the closest project.json near the module, if none is found it will try the next file target in the array (`package.json` in this case). Since even for NX Monorepos there is at least one `package.json` in the root and a `README.md` next to it, it will be used.

Note that this change also introduces the possibility to set `"readmeTargets": ["README.md"]` and this is powerfull because it would find the README.md that is closest to the module source file.