### PR TITLE
Auto submodules, auto workspaces, build on install; support standard build call

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knodes/typedoc-plugins",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "description": "A monorepo containing all knodes-published TypeDoc plugins",
   "license": "MIT",
   "private": true,
@@ -24,6 +24,8 @@
     "./packages/*"
   ],
   "scripts": {
+    "postinstall": "git submodule update --init --recursive && npm i --workspaces && npm run projects:build",
+    "build": "npm run projects:build",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "docs": "typedoc",
     "format:pkg": "format-package --write",

--- a/packages/plugin-pages/src/plugin.ts
+++ b/packages/plugin-pages/src/plugin.ts
@@ -21,7 +21,7 @@ export class PagesPlugin extends ABasePlugin {
 	}
 
 	/**
-	 * This method is called after the plugin has been instanciated.
+	 * This method is called after the plugin has been instantiated.
 	 */
 	public override initialize(){
 		const opts = this.pluginOptions.getValue();

--- a/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.spec.ts
+++ b/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.spec.ts
@@ -121,6 +121,13 @@ describe( APageTreeBuilder.name, () => {
 			matchReflection( PageReflection, { name: 'Baz', depth: 0, module: testHost.project, sourceFilePath: 'baz.md', content: 'Baz content', url: 'baz.html' } ),
 		] );
 	} );
+	it( 'should map hidden item', () => {
+		setVirtualFs( {
+			'foo.md': 'Foo content'
+		} );
+		const out = testHost.mapPagesToReflections( [ { title: 'HIDDEN', source: 'foo.md' } ] );
+		expect( out ).toHaveLength( 1 );
+	} );
 	it( 'should map page with children', () => {
 		setVirtualFs( {
 			'foo.md': 'Foo content',

--- a/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.ts
+++ b/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.ts
@@ -145,6 +145,12 @@ export abstract class APageTreeBuilder implements IPageTreeBuilder {
 		}
 		this.project.registerReflection( nodeReflection );
 		this.addNodeToProjectAsChild( nodeReflection );
+    // strip a hidden node, but *after* adding its source to the project as a child
+		if( node.title === 'HIDDEN' ){
+			return node.children ?
+				this._mapPagesToReflections( node.children, parent, childrenIO ) :
+				[];
+		}
 		const children = node.children ?
 			this._mapPagesToReflections(
 				node.children,


### PR DESCRIPTION
On install, attempt to:

* install git submodules automatically, 
* set up workspaces automatically, 
* and build once 

Also, stub the standard build call to point to project build.  

Currently untested due to KnodesCommunity/typedoc-plugins#82