### PR TITLE
Implement hidden nodes blind

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knodes/typedoc-plugins",
-  "version": "0.22.6",
+  "version": "0.22.7",
   "description": "A monorepo containing all knodes-published TypeDoc plugins",
   "license": "MIT",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knodes/typedoc-plugins",
-  "version": "0.22.5",
+  "version": "0.22.6",
   "description": "A monorepo containing all knodes-published TypeDoc plugins",
   "license": "MIT",
   "private": true,
@@ -24,6 +24,8 @@
     "./packages/*"
   ],
   "scripts": {
+    "postinstall": "git submodule update --init --recursive && npm i --workspaces && npm run projects:build",
+    "build": "npm run projects:build",
     "changelog": "conventional-changelog -p angular -i CHANGELOG.md -s",
     "docs": "typedoc",
     "format:pkg": "format-package --write",

--- a/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.spec.ts
+++ b/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.spec.ts
@@ -121,6 +121,13 @@ describe( APageTreeBuilder.name, () => {
 			matchReflection( PageReflection, { name: 'Baz', depth: 0, module: testHost.project, sourceFilePath: 'baz.md', content: 'Baz content', url: 'baz.html' } ),
 		] );
 	} );
+	it( 'should map hidden item', () => {
+		setVirtualFs( {
+			'foo.md': 'Foo content'
+		} );
+		const out = testHost.mapPagesToReflections( [ { title: 'HIDDEN', source: 'foo.md' } ] );
+		expect( out ).toHaveLength( 1 );
+	} );
 	it( 'should map page with children', () => {
 		setVirtualFs( {
 			'foo.md': 'Foo content',

--- a/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.ts
+++ b/packages/plugin-pages/src/theme-plugins/page-tree/a-page-tree-builder.ts
@@ -145,6 +145,12 @@ export abstract class APageTreeBuilder implements IPageTreeBuilder {
 		}
 		this.project.registerReflection( nodeReflection );
 		this.addNodeToProjectAsChild( nodeReflection );
+    // strip a hidden node, but *after* adding its source to the project as a child
+		if( node.title === 'HIDDEN' ){
+			return node.children ?
+				this._mapPagesToReflections( node.children, parent, childrenIO ) :
+				[];
+		}
 		const children = node.children ?
 			this._mapPagesToReflections(
 				node.children,


### PR DESCRIPTION
> Please merge https://github.com/KnodesCommunity/typedoc-plugins/pull/88 first
>
> Some of this PR is actually from parent patch 88, and will disappear when it is merged

This is a blind attempt to implement `HIDDEN` nodes.  It is highly suspect because the author could not build or test the result, and is new to this codebase.

A `HIDDEN` node is a node which will only render in the page tree if it's currently being viewed.  (This behavior is known to currently be incorrect, and will be repaired before merge once buildable.)

The purpose of a HIDDEN node is to allow a category page to include hundreds of pages underneath, and not flood the index on the right.  HIDDEN nodes must be found from a listing in another page, or through search.

My personal use case is for the documentation for a state machine library.  I want to include more than 200 example state machines.