### PR TITLE
Continuous integration; commented-out continuous deployment

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,83 @@
+name: Full publish pipeline
+
+on: [push]
+
+jobs:
+
+
+
+  build:
+
+    strategy:
+      matrix:
+        include:
+          - node-version: 18.x   # fastest, so run first, to error fast
+            os: ubuntu-latest
+          - node-version: 18.x   # slowest, so run next. sort by slowest from here to get earliest end through parallelism
+            os: macos-latest
+          - node-version: 18.x   # finish check big-3 on latest current
+            os: windows-latest
+          - node-version: 13.x  # lastly check just ubuntu on historic node versions because speed, oldest (slowest) first
+            os: ubuntu-latest
+          - node-version: 14.x
+            os: ubuntu-latest
+          - node-version: 15.x
+            os: ubuntu-latest
+          - node-version: 16.x
+            os: ubuntu-latest
+          - node-version: 17.x
+            os: ubuntu-latest
+
+    runs-on: ${{matrix.os}}
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: npm install, build, and test
+      run: |
+        npm install && npm run build
+      env:
+        CI: true
+        
+        
+  # release:
+
+  #   if: (github.event.pusher.name == github.event.repository.owner.name) && (github.ref == 'refs/heads/main')
+
+  #   needs: [build, verify-version-bump]
+
+  #   runs-on: ubuntu-latest
+
+  #   steps:
+  #   - uses: actions/checkout@v2
+
+  #   - name: Export tag to envvars
+  #     run: |
+  #       export TAG=$(awk -F'"' '/"version": ".+"/{ print $4; exit; }' package.json)
+  #       echo "TAG=$TAG" >> $GITHUB_ENV
+  #   - name: Use Node.js 18.x
+  #     uses: actions/setup-node@v1
+  #     with:
+  #       node-version: 18.x
+  #       registry-url: https://registry.npmjs.org/
+
+  #   - name: Push tags
+  #     run: git push origin --tags
+
+  #   - name: Create the release
+  #     uses: actions/create-release@v1
+  #     env:
+  #       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  #     with:
+  #       tag_name: ${{ env.TAG }}
+  #       release_name: ${{ env.TAG }}
+  #       body_path: CHANGELOG.md
+
+  #   - name: Publish to npm
+  #     run: |
+  #       npm publish
+  #     env:
+  #       NODE_AUTH_TOKEN: ${{ secrets.PUBLISH_TOKEN_FOR_GH_CI_CD }}        


### PR DESCRIPTION
This PR implements Github Actions for the repository.  There are two `steps` in the PR.  One is wholesale commented out, but ready for use.

&nbsp;

# That which exists

The present `step` is a full build pipeline.  It makes a build under node 18 for each of the three major platforms (ubuntu windows mac,) then ubuntu for every current version back through `node 13`, in reverse order.

The reason for this order is that Windows and Mac runners tend to be much slower on GHA than Ubuntu runners, and newer node tends to be faster than older node, so we run the single fastest one first to get soonest feedback, then slowest-next through the entire batch to get soonest completion.

You can easily change whether node 13 is the starting point by adding or removing entries to/from the matrix at line 20.  Please continue to feed them in before 13 in reverse order, if adding.

For each env, the simple `npm install && npm run build` is issued.  I assume that test is part of build, but haven't looked carefully.

&nbsp;

# That which does not

The commented out step is a full deploy to NPM, as well as the generation of a github release, and the pushing of tags to the repo itself.  

***This step is gated to pushes by the owner*** (line 48.)  Other people merging to main ***will not*** trigger a publish, as a safety measure.

In order for this to work, first you must:

1. Go to npmjs.com and log in
2. Create an "automation token" there
3. Bring the "automation token" to Github 
4. Place it in repository settings, under `secrets` / `actions`, as a `repository secret`, with all surrounding whitespace removed
5. Either use the name `PUBLISH_TOKEN_FOR_GH_CI_CD` there, or change line 83 here to whatever you chose instead

This is a reduced version of [my state machine's action setup](https://github.com/StoneCypher/jssm/blob/main/.github/workflows/nodejs.yml), and [I have been using it for some time](https://github.com/StoneCypher/jssm/actions) with [success](https://npmjs.com/package/jssm)